### PR TITLE
Fix potential overflow of signed long (should be unsigned)

### DIFF
--- a/src/IRReceive.hpp
+++ b/src/IRReceive.hpp
@@ -663,8 +663,8 @@ uint8_t IRrecv::compare(unsigned int oldval, unsigned int newval) {
     return 1;
 }
 
-#define FNV_PRIME_32 16777619   ///< used for decodeHash()
-#define FNV_BASIS_32 2166136261 ///< used for decodeHash()
+#define FNV_PRIME_32 16777619UL   ///< used for decodeHash()
+#define FNV_BASIS_32 2166136261UL ///< used for decodeHash()
 
 /**
  * decodeHash - decode an arbitrary IR code.
@@ -685,7 +685,7 @@ uint8_t IRrecv::compare(unsigned int oldval, unsigned int newval) {
  * see: http://www.righto.com/2010/01/using-arbitrary-remotes-with-arduino.html
  */
 bool IRrecv::decodeHash() {
-    long hash = FNV_BASIS_32;
+    unsigned long hash = FNV_BASIS_32;
 
 // Require at least 6 samples to prevent triggering on noise
     if (decodedIRData.rawDataPtr->rawlen < 6) {
@@ -711,7 +711,7 @@ bool IRrecv::decodeHash() {
 
 #  if !defined(NO_LEGACY_COMPATIBILITY)
 bool IRrecv::decodeHashOld(decode_results *aResults) {
-    long hash = FNV_BASIS_32;
+    unsigned long hash = FNV_BASIS_32;
 
 // Require at least 6 samples to prevent triggering on noise
     if (aResults->rawlen < 6) {


### PR DESCRIPTION
This patch fixes an overflow condition in the "hash" decoder. Actually the constant FNV_BASIS_32 does not fit into the "long" datatype on AVR.
Note that you will only see this warning if you edit platform.txt to include "-pedantic" into compiler.warning_flags.

The warning is:
In file included from D:\ARDUINO_Work\WORK\libraries\IRremote\src/IRremote.hpp:221:0,
                 from D:\ARDUINO_Work\WORK\libraries\IRremote\examples\ReceiveAndSend\ReceiveAndSend.ino:54:
D:\ARDUINO_Work\WORK\libraries\IRremote\src/IRReceive.hpp: In member function 'bool IRrecv::decodeHash()':
D:\ARDUINO_Work\WORK\libraries\IRremote\src/IRReceive.hpp:667:22: warning: overflow in implicit constant conversion [-Woverflow]
 #define FNV_BASIS_32 2166136261 ///< used for decodeHash()
                      ^
D:\ARDUINO_Work\WORK\libraries\IRremote\src/IRReceive.hpp:688:17: note: in expansion of macro 'FNV_BASIS_32'
     long hash = FNV_BASIS_32;
                 ^~~~~~~~~~~~
D:\ARDUINO_Work\WORK\libraries\IRremote\src/IRReceive.hpp: In member function 'bool IRrecv::decodeHashOld(decode_results*)':
D:\ARDUINO_Work\WORK\libraries\IRremote\src/IRReceive.hpp:667:22: warning: overflow in implicit constant conversion [-Woverflow]
 #define FNV_BASIS_32 2166136261 ///< used for decodeHash()
                      ^
D:\ARDUINO_Work\WORK\libraries\IRremote\src/IRReceive.hpp:714:17: note: in expansion of macro 'FNV_BASIS_32'
     long hash = FNV_BASIS_32;
                 ^~~~~~~~~~~~